### PR TITLE
whitespaces in sub_filter directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This module beautifies and formats Nginx configuration files like so:
 * all lines are indented in uniform manner, with 4 spaces per level
 * neighbouring empty lines are collapsed to at most two empty lines
 * curly braces placement follows Java convention
-* whitespaces are collapsed, except in comments an quotation marks
+* whitespaces are collapsed, except in comments an quotation marks and sub_filter directive
 
 # Need to format quickly?
 Use [vasilevich](https://github.com/vasilevich/) website: [nginxbeautifier.com](https://nginxbeautifier.com)

--- a/nginxbeautify/main.js
+++ b/nginxbeautify/main.js
@@ -120,7 +120,7 @@
 
             for (var index = 0, newline = 0; index < splittedByLines.length; index++) {
                 splittedByLines[index] = splittedByLines[index].trim();
-                if (!splittedByLines[index].startsWith("#") && splittedByLines[index] != "") {
+                if (!splittedByLines[index].startsWith("#") && !splittedByLines[index].startsWith("sub_filter") && splittedByLines[index] != "") {
                     newline = 0;
                     var line = splittedByLines[index] = this.strip_line(splittedByLines[index]);
                     if (line != "}" && line != "{") {


### PR DESCRIPTION
Fix whitespace replacement in [sub_filter directive](http://nginx.org/en/docs/http/ngx_http_sub_module.html)

Before:
`sub_filter '<div>`&nbsp;&nbsp; `</div>'  '<div>NEW_CONTENT</div>';`

after beautify:
`sub_filter '<div>`&nbsp;`</div>'  '<div>NEW_CONTENT</div>';`
